### PR TITLE
Enabled certbot restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - .env
     volumes:
       - "letsencrypt:/etc/letsencrypt"
-    # restart: unless-stopped (optional)
+    restart: unless-stopped (optional)
 
     # Add your frontend configuration here
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - .env
     volumes:
       - "letsencrypt:/etc/letsencrypt"
-    restart: unless-stopped (optional)
+    restart: unless-stopped
 
     # Add your frontend configuration here
   frontend:


### PR DESCRIPTION
Without this, other services that depend on it - namely the ssl-service - will not start correctly.